### PR TITLE
Tweak test

### DIFF
--- a/search_flip.gemspec
+++ b/search_flip.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "mocha"
-  spec.add_development_dependency "factory_girl"
+  spec.add_development_dependency "factory_bot"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "activerecord", ">= 3.0"
   spec.add_development_dependency "webmock"
@@ -32,4 +32,3 @@ Gem::Specification.new do |spec|
   spec.add_dependency "hashie"
   spec.add_dependency "oj"
 end
-

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,7 @@ require "webmock/minitest"
 require "mocha/mini_test"
 require "search_flip"
 require "active_record"
-require "factory_girl"
+require "factory_bot"
 require "timecop"
 require "yaml"
 
@@ -35,7 +35,7 @@ class Product < ActiveRecord::Base
   has_many :comments
 end
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :product
 end
 
@@ -50,7 +50,7 @@ class User < ActiveRecord::Base
   has_many :products
 end
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :user
 end
 
@@ -68,7 +68,7 @@ class Comment < ActiveRecord::Base
   belongs_to :product
 end
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :comment
 end
 
@@ -170,7 +170,7 @@ end
 TestIndex.delete_index if TestIndex.index_exists?
 
 class SearchFlip::TestCase < MiniTest::Test
-  include FactoryGirl::Syntax::Methods
+  include FactoryBot::Syntax::Methods
 
   def self.should_delegate_method(method, to:, subject:, as: method)
     define_method :"test_delegate_#{method}_to_#{to}" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,7 @@
 require "minitest"
 require "minitest/autorun"
 require "webmock/minitest"
-require "mocha/mini_test"
+require "mocha/minitest"
 require "search_flip"
 require "active_record"
 require "factory_bot"
@@ -240,4 +240,3 @@ class SearchFlip::TestCase < MiniTest::Test
     Product.delete_all
   end
 end
-


### PR DESCRIPTION
This PR fixes 2 deprecation warning on test.

```
The factory_girl gem has been deprecated and has been replaced by factory_bot. Please switch to factory_bot as soon as possible.
```

```
Mocha deprecation warning at /Users/fukayatsu/.rbenv/versions/2.5.0/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:135:in `require': `require 'mocha/mini_test'` has been deprecated. Please use `require 'mocha/minitest' instead.
```