### PR TITLE
Aws signed requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 
 # CHANGELOG
 
+## v3.1.0
+
+* Added plugin support in `SearchFlip::HTTPClient`
+* Added `SearchFlip::AwsSigv4Plugin` to be able to use AWS Elasticsearch with
+  signed requests
+
 ## v3.0.0
 
 * Added `Criteria#to_query`, which returns a raw query including all queries

--- a/README.md
+++ b/README.md
@@ -475,8 +475,8 @@ end
 ```
 
 Generally, aggregation results returned by Elasticsearch are returned as a
-`SearchFlip::Result`, which basically is `Hashie::Mash`such that you can access
-them via:
+`SearchFlip::Result`, which basically is a `Hashie::Mash`, such that you can
+access them via:
 
 ```ruby
 query.aggregations(:username)["mrkamel"].revenue.value
@@ -794,7 +794,7 @@ MyConnection = SearchFlip::Connection.new(
 
 Again, in your index you need to specify this connection:
 
-```
+```ruby
 class MyIndex
   include SearchFlip::Index
 

--- a/README.md
+++ b/README.md
@@ -772,7 +772,7 @@ SearchFlip::Connection.new(base_url: "...", http_client: http_client)
 ## AWS Elasticsearch / Signed Requests
 
 To use SearchFlip with AWS Elasticsearch and signed requests, you have to add
-at `aws-sdk-core` to your Gemfile and tell SearchFlip to use the
+`aws-sdk-core` to your Gemfile and tell SearchFlip to use the
 `SearchFlip::AwsSigv4Plugin`:
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -769,6 +769,41 @@ http_client = http_client.headers(key: "value")
 SearchFlip::Connection.new(base_url: "...", http_client: http_client)
 ```
 
+## AWS Elasticsearch / Signed Requests
+
+To use SearchFlip with AWS Elasticsearch and signed requests, you have to add
+at `aws-sdk-core` to your Gemfile and tell SearchFlip to use the
+`SearchFlip::AwsSigv4Plugin`:
+
+```ruby
+require "search_flip/aws_sigv4_plugin"
+
+MyConnection = SearchFlip::Connection.new(
+  base_url: "https://your-elasticsearch-cluster.es.amazonaws.com",
+  http_client: SearchFlip::HTTPClient.new(
+    plugins: [
+      SearchFlip::AwsSigv4Plugin.new(
+        region: "...",
+        access_key_id: "...",
+        secret_access_key: "..."
+      )
+    ]
+  )
+)
+```
+
+Again, in your index you need to specify this connection:
+
+```
+class MyIndex
+  include SearchFlip::Index
+
+  def self.connection
+    MyConnection
+  end
+end
+```
+
 ## Routing and other index-time options
 
 Override `index_options` in case you want to use routing or pass other

--- a/lib/search_flip/aws_sigv4_plugin.rb
+++ b/lib/search_flip/aws_sigv4_plugin.rb
@@ -29,7 +29,7 @@ module SearchFlip
 
     def call(request, method, uri, options = {})
       full_uri = URI.parse(uri)
-      full_uri.query = URI.encode_www_form(options[:params].to_a) if options[:params]
+      full_uri.query = URI.encode_www_form(options[:params]) if options[:params]
 
       signature_request = {
         http_method: method.to_s.upcase,

--- a/lib/search_flip/aws_sigv4_plugin.rb
+++ b/lib/search_flip/aws_sigv4_plugin.rb
@@ -1,0 +1,29 @@
+require "aws-sdk-core"
+require "uri"
+
+module SearchFlip
+  class AwsSigv4Plugin
+    attr_accessor :signer
+
+    def initialize(options = {})
+      self.signer = Aws::Sigv4::Signer.new({ service: "es" }.merge(options))
+    end
+
+    def call(request, method, uri, options = {})
+      full_uri = URI.parse(uri)
+      full_uri.query = URI.encode_www_form(options[:params].to_a) if options[:params]
+
+      signature_request = {
+        http_method: method.to_s.upcase,
+        url: full_uri.to_s
+      }
+
+      signature_request[:body] = options[:body] if options.key?(:body)
+      signature_request[:body] = options[:json].respond_to?(:to_str) ? options[:json] : JSON.generate(options[:json]) if options[:json]
+
+      signature = signer.sign_request(signature_request)
+
+      request.headers(signature.headers)
+    end
+  end
+end

--- a/lib/search_flip/aws_sigv4_plugin.rb
+++ b/lib/search_flip/aws_sigv4_plugin.rb
@@ -2,6 +2,24 @@ require "aws-sdk-core"
 require "uri"
 
 module SearchFlip
+  # The SearchFlip::AwsSigV4Plugin is a plugin for the SearchFlip::HTTPClient
+  # to be used with AWS Elasticsearch to sign requests, i.e. add signed
+  # headers, before sending the request to Elasticsearch.
+  #
+  # @example
+  #   MyConnection = SearchFlip::Connection.new(
+  #     base_url: "https://your-elasticsearch-cluster.es.amazonaws.com",
+  #     http_client: SearchFlip::HTTPClient.new(
+  #       plugins: [
+  #         SearchFlip::AwsSigv4Plugin.new(
+  #           region: "...",
+  #           access_key_id: "...",
+  #           secret_access_key: "..."
+  #         )
+  #       ]
+  #     )
+  #   )
+
   class AwsSigv4Plugin
     attr_accessor :signer
 

--- a/lib/search_flip/http_client.rb
+++ b/lib/search_flip/http_client.rb
@@ -1,6 +1,4 @@
 module SearchFlip
-  # @api private
-  #
   # The SearchFlip::HTTPClient class wraps the http gem, is for internal use
   # and responsible for the http request/response handling, ie communicating
   # with Elasticsearch.

--- a/search_flip.gemspec
+++ b/search_flip.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   MESSAGE
 
   spec.add_development_dependency "activerecord", ">= 3.0"
+  spec.add_development_dependency "aws-sdk-core"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "factory_bot"
   spec.add_development_dependency "rake"

--- a/spec/search_flip/aws_sigv4_plugin_spec.rb
+++ b/spec/search_flip/aws_sigv4_plugin_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe SearchFlip::AwsSigv4Plugin do
     end
 
     it "feeds the http method, full url and body to the signer" do
-      signing_request =  {
+      signing_request = {
         http_method: "GET",
         url: "http://localhost/index?param=value",
         body: JSON.generate(key: "value")

--- a/spec/search_flip/aws_sigv4_plugin_spec.rb
+++ b/spec/search_flip/aws_sigv4_plugin_spec.rb
@@ -1,0 +1,41 @@
+require File.expand_path("../spec_helper", __dir__)
+require "search_flip/aws_sigv4_plugin"
+
+RSpec.describe SearchFlip::AwsSigv4Plugin do
+  describe "#call" do
+    subject(:plugin) do
+      SearchFlip::AwsSigv4Plugin.new(
+        region: "us-east-1",
+        access_key_id: "access key",
+        secret_access_key: "secret access key"
+      )
+    end
+
+    let(:client) { SearchFlip::HTTPClient.new }
+
+    it "adds the signed headers to the request" do
+      Timecop.freeze Time.parse("2020-01-01 12:00:00 UTC") do
+        expect(client).to receive(:headers).with(
+          "host" => "localhost",
+          "authorization" => /.*/,
+          "x-amz-content-sha256" => /.*/,
+          "x-amz-date" => /20200101T120000Z/
+        )
+
+        plugin.call(client, :get, "http://localhost/index")
+      end
+    end
+
+    it "feeds the http method, full url and body to the signer" do
+      signing_request =  {
+        http_method: "GET",
+        url: "http://localhost/index?param=value",
+        body: JSON.generate(key: "value")
+      }
+
+      expect(plugin.signer).to receive(:sign_request).with(signing_request).and_call_original
+
+      plugin.call(client, :get, "http://localhost/index", params: { param: "value" }, json: { key: "value" })
+    end
+  end
+end

--- a/spec/search_flip/http_client_spec.rb
+++ b/spec/search_flip/http_client_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe SearchFlip::HTTPClient do
     subject do
       SearchFlip::HTTPClient.new(
         plugins: [
-          ->(request, method, uri, options = {}) { request.headers("First-Header" => "Value") },
-          ->(request, method, uri, options = {}) { request.headers("Second-Header" => "Value") }
+          ->(request, _method, _uri, _options = {}) { request.headers("First-Header" => "Value") },
+          ->(request, _method, _uri, _options = {}) { request.headers("Second-Header" => "Value") }
         ]
       )
     end

--- a/spec/search_flip/http_client_spec.rb
+++ b/spec/search_flip/http_client_spec.rb
@@ -39,6 +39,23 @@ RSpec.describe SearchFlip::HTTPClient do
     end
   end
 
+  describe "plugins" do
+    subject do
+      SearchFlip::HTTPClient.new(
+        plugins: [
+          ->(request, method, uri, options = {}) { request.headers("First-Header" => "Value") },
+          ->(request, method, uri, options = {}) { request.headers("Second-Header" => "Value") }
+        ]
+      )
+    end
+
+    it "injects the plugins and uses their result in the request" do
+      stub_request(:get, "http://localhost/path").with(query: { key: "value" }, headers: { "First-Header" => "Value", "Second-Header" => "Value" }).and_return(body: "success")
+
+      expect(subject.get("http://localhost/path", params: { key: "value" }).body.to_s).to eq("success")
+    end
+  end
+
   [:via, :basic_auth, :auth].each do |method|
     describe "##{method}" do
       it "creates a dupped instance" do


### PR DESCRIPTION
Adds support for plugins within the http client and adds a `AwsSigv4Plugin` to sign requests before sending them to AWS Elasticsearch.