### PR TITLE
Fix regarding AWS signatures #32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # CHANGELOG
 
+## v3.7.2
+
+* Fix wrong AWS signatures by generating the json before passing it to http-rb
+
 ## v3.7.1
 
 * Fix thread-safety issue of http-rb

--- a/lib/search_flip/aws_sigv4_plugin.rb
+++ b/lib/search_flip/aws_sigv4_plugin.rb
@@ -37,7 +37,6 @@ module SearchFlip
       }
 
       signature_request[:body] = options[:body] if options.key?(:body)
-      signature_request[:body] = options[:json].respond_to?(:to_str) ? options[:json] : JSON.generate(options[:json]) if options[:json]
 
       signature = signer.sign_request(signature_request)
 

--- a/lib/search_flip/http_client.rb
+++ b/lib/search_flip/http_client.rb
@@ -67,7 +67,7 @@ module SearchFlip
         # guarantee that json is always generated as stated in the config
 
         opts[:body] = JSON.generate(opts.delete(:json))
-        final_request = final_request.headers("Content-Type" => "application/json")
+        final_request = final_request.headers(content_type: "application/json")
       end
 
       final_request = plugins.inject(final_request) { |res, cur| cur.call(res, method, uri, opts) }

--- a/lib/search_flip/version.rb
+++ b/lib/search_flip/version.rb
@@ -1,3 +1,3 @@
 module SearchFlip
-  VERSION = "3.7.1"
+  VERSION = "3.7.2"
 end

--- a/spec/search_flip/aws_sigv4_plugin_spec.rb
+++ b/spec/search_flip/aws_sigv4_plugin_spec.rb
@@ -29,15 +29,17 @@ RSpec.describe SearchFlip::AwsSigv4Plugin do
     end
 
     it "feeds the http method, full url and body to the signer" do
+      body = JSON.generate(key: "value")
+
       signing_request = {
         http_method: "GET",
         url: "http://localhost/index?param=value",
-        body: JSON.generate(key: "value")
+        body: body
       }
 
       expect(plugin.signer).to receive(:sign_request).with(signing_request).and_call_original
 
-      plugin.call(client, :get, "http://localhost/index", params: { param: "value" }, json: { key: "value" })
+      plugin.call(client, :get, "http://localhost/index", params: { param: "value" }, body: body)
     end
   end
 end

--- a/spec/search_flip/http_client_spec.rb
+++ b/spec/search_flip/http_client_spec.rb
@@ -36,6 +36,12 @@ RSpec.describe SearchFlip::HTTPClient do
 
         expect(SearchFlip::HTTPClient.new.send(method, "http://localhost/path", body: "body", params: { key: "value" }).body.to_s).to eq("success")
       end
+
+      it "generates json, passes it as body and sets the content type when the json option is used" do
+        stub_request(method, "http://localhost/path").with(body: '{"key":"value"}', headers: { "Content-Type" => "application/json" }).to_return(body: "success")
+
+        expect(SearchFlip::HTTPClient.new.send(method, "http://localhost/path", json: { "key" => "value" }).body.to_s).to eq("success")
+      end
     end
   end
 


### PR DESCRIPTION
Using the `json: ...` option of http-rb can lead to a AWS signature mismatch, since SearchFlip is using Oj to generate the json for which the signature is calculated, while http-rb is not using Oj. This results in different json being sent over the wire and being used for calculating the signature. More concretely, http-rb is using `.to_json` when available and `.to_json` e.g. encodes `&` as `\\u0026` while Oj is not. To fix that `SearchFlip::HttpClient` now takes the `json` option, generates the json using Oj and passes it as `body` to http-rb instead.