### PR TITLE
http.rb version 6 compatibility

### DIFF
--- a/lib/search_flip/http_client.rb
+++ b/lib/search_flip/http_client.rb
@@ -73,7 +73,7 @@ module SearchFlip
       final_request = plugins.inject(final_request) { |res, cur| cur.call(res, method, uri, opts) }
       final_request = final_request.headers({}) # Prevent thread-safety issue of http-rb: https://github.com/httprb/http/issues/558
 
-      response = final_request.request.send(method, uri, opts)
+      response = final_request.request.send(method, uri, **opts)
 
       raise SearchFlip::ResponseError.new(code: response.code, body: response.body.to_s) unless response.status.success?
 


### PR DESCRIPTION
Fixes #43 

Change hash to keywords for `http.rb` version 6 compatibility.  Passing a hash is now disallowed, but keywords work (and are supported in older version).

https://github.com/httprb/http/blob/main/CHANGELOG.md
From the http.rb changelog:

> BREAKING Convert options hash parameters to explicit keyword arguments across the public API. Methods like HTTP.get(url, body: "data") continue to work, but passing an explicit hash (e.g., HTTP.get(url, {body: "data"})) is no longer supported, and unrecognized keyword arguments now raise ArgumentError. Affected methods: all HTTP verb methods (get, post, etc.), request, follow, retriable, URI.new, Request.new, Response.new, Redirector.new, Retriable::Performer.new, Retriable::DelayCalculator.new, and Timeout::Null.new (and subclasses). HTTP::URI.new also no longer accepts Addressable::URI objects.